### PR TITLE
Auto-lock lineups at qualifying time

### DIFF
--- a/app.py
+++ b/app.py
@@ -660,8 +660,13 @@ def get_locked_out_constructors(db, user_id):
 
 
 def is_lineup_locked(db):
+    from datetime import datetime, timezone
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+    # Locked if quali time has passed and not manually unlocked (quali_locked = -1)
+    # quali_locked: 0 = default (auto), 1 = manually locked, -1 = manually unlocked
     row = db.execute(
-        "SELECT COUNT(*) as c FROM races WHERE quali_locked = 1 AND completed = 0"
+        "SELECT COUNT(*) as c FROM races WHERE completed = 0 AND quali_locked != -1 AND quali_datetime <= ?",
+        (now_utc,)
     ).fetchone()
     return row["c"] > 0
 
@@ -1415,15 +1420,9 @@ def admin():
     if request.method == "POST":
         action = request.form.get("action")
 
-        if action == "lock_quali":
+        if action == "unlock_quali":
             race_id = request.form.get("race_id")
-            db.execute("UPDATE races SET quali_locked = 1 WHERE id = ?", (race_id,))
-            db.commit()
-            flash("Qualifying locked! Lineups are now frozen.", "success")
-
-        elif action == "unlock_quali":
-            race_id = request.form.get("race_id")
-            db.execute("UPDATE races SET quali_locked = 0 WHERE id = ?", (race_id,))
+            db.execute("UPDATE races SET quali_locked = -1 WHERE id = ?", (race_id,))
             db.commit()
             flash("Lineup lock removed.", "success")
 
@@ -1597,7 +1596,9 @@ def admin():
             "constructors": team_constructors,
         }
 
-    return render_template("admin.html", races=races, drivers=drivers, users=users, adjustments=adjustments, all_user_teams=all_user_teams)
+    from datetime import datetime, timezone
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+    return render_template("admin.html", races=races, drivers=drivers, users=users, adjustments=adjustments, all_user_teams=all_user_teams, now_utc=now_utc)
 
 
 @app.route("/admin/login", methods=["GET", "POST"])
@@ -1713,7 +1714,7 @@ def score_race(db, race_id, rescore=False):
 
     if not rescore:
         process_lock_decrements(db, race_id)
-    db.execute("UPDATE races SET completed = 1, quali_locked = 0 WHERE id = ?", (race_id,))
+    db.execute("UPDATE races SET completed = 1 WHERE id = ?", (race_id,))
     db.commit()
 
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -41,31 +41,19 @@
             </form>
         </div>
 
-        <!-- Lock/Unlock Qualifying -->
+        <!-- Unlock Lineups -->
         <div class="card">
-            <h2>Lineup Lock (Qualifying)</h2>
+            <h2>Unlock Lineups</h2>
             <p style="color: var(--text-dim); font-size: .9rem; margin-bottom: 1rem;">
-                Lock lineups when qualifying starts. Unlock happens automatically when the race is scored.
+                Lineups lock automatically at qualifying time. Use this to manually unlock if needed.
             </p>
-            <form method="POST" style="margin-bottom: 1rem;">
-                <input type="hidden" name="action" value="lock_quali">
-                <div class="form-group">
-                    <label>Lock Qualifying For</label>
-                    <select name="race_id" required>
-                        {% for r in races if not r.completed and not r.quali_locked %}
-                        <option value="{{ r.id }}">R{{ r.round }} - {{ r.name }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <button type="submit" class="btn btn-primary">Lock Lineups</button>
-            </form>
             <form method="POST">
                 <input type="hidden" name="action" value="unlock_quali">
                 <div class="form-group">
-                    <label>Unlock (if needed)</label>
+                    <label>Unlock Race</label>
                     <select name="race_id" required>
-                        {% for r in races if r.quali_locked and not r.completed %}
-                        <option value="{{ r.id }}">R{{ r.round }} - {{ r.name }} (LOCKED)</option>
+                        {% for r in races if not r.completed %}
+                        <option value="{{ r.id }}">R{{ r.round }} - {{ r.name }}</option>
                         {% endfor %}
                     </select>
                 </div>
@@ -95,7 +83,9 @@
                     <td>
                         {% if r.completed %}
                         <span class="race-badge done">Scored</span>
-                        {% elif r.quali_locked %}
+                        {% elif r.quali_locked == -1 %}
+                        <span style="color: #2ecc71; font-size: .85rem;">Unlocked</span>
+                        {% elif r.quali_datetime <= now_utc %}
                         <span class="race-badge locked-badge">Locked</span>
                         {% else %}
                         <span style="color: var(--text-dim); font-size: .85rem;">Pending</span>


### PR DESCRIPTION
## Summary
- Lineups now lock automatically when the qualifying datetime passes (no manual lock needed)
- Admin panel has an unlock button for manual override when needed
- Scoring no longer auto-unlocks lineups
- `quali_locked` values: `0` = default (auto), `-1` = manually unlocked

## Test plan
- [ ] Verify lineups are locked after quali time passes
- [ ] Verify admin can manually unlock a race
- [ ] Verify scoring doesn't auto-unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)