### PR TITLE
Fix NameError: undefined 'laps' variable in scoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -388,7 +388,7 @@ def calc_driver_race_points(result, teammate_finish=None, db=None):
         pts += SPRINT_PTS.get(sp, 0)
 
     # Completion points
-    pts += calc_completion_pts(laps, result["total_laps"])
+    pts += calc_completion_pts(result["laps"], result["total_laps"])
 
     # Beating teammate
     if teammate_finish:


### PR DESCRIPTION
## Summary
- Fixes a crash when scoring a race (`NameError: name 'laps' is not defined`)
- PR #14 (Scores Fixed) removed the local `laps` variable that PR #13 (DNS fix) had introduced, but left a reference to it in `calc_completion_pts(laps, ...)`
- Changed to `calc_completion_pts(result["laps"], ...)` which reads laps directly from the race result

## Root cause
Merge conflict between PR #13 and #14 left a dangling reference to a variable that no longer existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)