### PR TITLE
Fix constructor not submitting with active contract

### DIFF
--- a/templates/team.html
+++ b/templates/team.html
@@ -160,7 +160,7 @@
                 <label class="picker-card {{ 'selected' if c.id|string in selected_constructor_ids }}{{ ' cooldown-card' if is_cooled_c }}" data-price="{{ c.price }}" data-type="constructor">
                     <input type="checkbox" name="constructors" value="{{ c.id }}"
                            {{ 'checked' if c.id|string in selected_constructor_ids }}
-                           {{ 'disabled' if is_cooled_c or c.id|string in active_constructor_contracts }}>
+                           {{ 'disabled' if is_cooled_c }}>
                     <div class="constructor-bar" style="background: {{ c.color }};"></div>
                     <div class="driver-info">
                         <h4>{{ c.name }}</h4>


### PR DESCRIPTION
## Problem
When a user tries to save their team without making changes, they get an error: "Must select exactly 1 constructor." This happens because constructors with active contracts had their checkbox set to `disabled`, which prevents the browser from including the value in the form submission. The backend then sees 0 constructors and rejects the save.

## Solution
Removed the `disabled` attribute for constructors with active contracts. Instead, the existing JavaScript lock prevention (via `lockedConstructorIds`) handles preventing users from unchecking them — same approach already used for drivers. The checkbox stays enabled so it submits with the form, but JS blocks any attempt to uncheck it.

## How it was caught
Saving an unchanged team with a locked constructor triggered the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)