### PR TITLE
Add Season League: fixed lineup for entire season

### DIFF
--- a/app.py
+++ b/app.py
@@ -1163,6 +1163,11 @@ def season():
     if request.method == "POST":
         new_turbo = request.form.get("turbo_driver", "")
         if new_turbo and not is_lineup_locked(db):
+            # Check salary cap
+            turbo_d = db.execute("SELECT price FROM drivers WHERE id = ?", (new_turbo,)).fetchone()
+            if turbo_d and turbo_d["price"] >= TURBO_SALARY_CAP:
+                flash(f"Turbo driver must be under ${TURBO_SALARY_CAP:.1f}M.", "error")
+                return redirect(url_for("season"))
             # Reset all turbo flags for this user's season team
             db.execute("UPDATE season_teams SET is_turbo = 0 WHERE user_id = ?", (user_id,))
             db.execute("UPDATE season_teams SET is_turbo = 1 WHERE user_id = ? AND driver_id = ?",
@@ -1252,6 +1257,7 @@ def season():
         has_season_team=has_season_team,
         lineup_locked=lineup_locked,
         turbo_id=turbo_id,
+        turbo_salary_cap=TURBO_SALARY_CAP,
         last_race_summary=last_race_summary,
         last_race_info=last_race_info,
     )
@@ -1306,6 +1312,7 @@ def season_team():
         "season_team.html",
         drivers=drivers,
         constructors=constructors,
+        turbo_salary_cap=TURBO_SALARY_CAP,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -1266,21 +1266,6 @@ def season_team():
             flash("You must select a turbo driver.", "error")
             return redirect(url_for("season_team"))
 
-        # Check budget
-        total_cost = 0
-        for did in driver_ids:
-            d = db.execute("SELECT price FROM drivers WHERE id = ?", (did,)).fetchone()
-            if d:
-                total_cost += d["price"]
-        for cid in constructor_ids:
-            c = db.execute("SELECT price FROM constructors WHERE id = ?", (cid,)).fetchone()
-            if c:
-                total_cost += c["price"]
-
-        if total_cost > 100.0:
-            flash("Team exceeds $100M budget.", "error")
-            return redirect(url_for("season_team"))
-
         # Save season team
         for i, did in enumerate(driver_ids):
             is_turbo = 1 if did == turbo_driver else 0
@@ -1303,7 +1288,6 @@ def season_team():
         "season_team.html",
         drivers=drivers,
         constructors=constructors,
-        turbo_salary_cap=TURBO_SALARY_CAP,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -1153,11 +1153,25 @@ def home():
 # Season League
 # ---------------------------------------------------------------------------
 
-@app.route("/season")
+@app.route("/season", methods=["GET", "POST"])
 @login_required
 def season():
     db = get_db()
     user_id = session["user_id"]
+
+    # Handle turbo change
+    if request.method == "POST":
+        new_turbo = request.form.get("turbo_driver", "")
+        if new_turbo and not is_lineup_locked(db):
+            # Reset all turbo flags for this user's season team
+            db.execute("UPDATE season_teams SET is_turbo = 0 WHERE user_id = ?", (user_id,))
+            db.execute("UPDATE season_teams SET is_turbo = 1 WHERE user_id = ? AND driver_id = ?",
+                        (user_id, new_turbo))
+            db.commit()
+            flash("Turbo driver updated!", "success")
+        elif is_lineup_locked(db):
+            flash("Lineups are locked. Can't change turbo driver.", "error")
+        return redirect(url_for("season"))
 
     last_race = db.execute(
         "SELECT id FROM races WHERE completed = 1 ORDER BY round DESC LIMIT 1"
@@ -1192,6 +1206,8 @@ def season():
     """, (user_id,)).fetchall()
 
     has_season_team = len(season_drivers) > 0
+    lineup_locked = is_lineup_locked(db)
+    turbo_id = next((str(d["id"]) for d in season_drivers if d["is_turbo"]), None)
 
     # Last race summary
     last_race_summary = []
@@ -1234,6 +1250,8 @@ def season():
         season_drivers=season_drivers,
         season_constructors=season_constructors,
         has_season_team=has_season_team,
+        lineup_locked=lineup_locked,
+        turbo_id=turbo_id,
         last_race_summary=last_race_summary,
         last_race_info=last_race_info,
     )

--- a/app.py
+++ b/app.py
@@ -282,6 +282,43 @@ CREATE TABLE IF NOT EXISTS pick_constructor_scores (
     points          INTEGER NOT NULL DEFAULT 0,
     UNIQUE(user_id, race_id, constructor_id)
 );
+
+CREATE TABLE IF NOT EXISTS season_teams (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL REFERENCES users(id),
+    driver_id       INTEGER REFERENCES drivers(id),
+    constructor_id  INTEGER REFERENCES constructors(id),
+    is_turbo        INTEGER NOT NULL DEFAULT 0,
+    slot            INTEGER NOT NULL,
+    UNIQUE(user_id, slot)
+);
+
+CREATE TABLE IF NOT EXISTS season_scores (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL REFERENCES users(id),
+    race_id     INTEGER NOT NULL REFERENCES races(id),
+    points      INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(user_id, race_id)
+);
+
+CREATE TABLE IF NOT EXISTS season_pick_scores (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL REFERENCES users(id),
+    race_id         INTEGER NOT NULL REFERENCES races(id),
+    driver_id       INTEGER REFERENCES drivers(id),
+    points          INTEGER NOT NULL DEFAULT 0,
+    is_turbo        INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(user_id, race_id, driver_id)
+);
+
+CREATE TABLE IF NOT EXISTS season_pick_constructor_scores (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL REFERENCES users(id),
+    race_id         INTEGER NOT NULL REFERENCES races(id),
+    constructor_id  INTEGER REFERENCES constructors(id),
+    points          INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(user_id, race_id, constructor_id)
+);
 """
 
 # ---------------------------------------------------------------------------
@@ -1112,6 +1149,164 @@ def home():
     )
 
 
+# ---------------------------------------------------------------------------
+# Season League
+# ---------------------------------------------------------------------------
+
+@app.route("/season")
+@login_required
+def season():
+    db = get_db()
+    user_id = session["user_id"]
+
+    last_race = db.execute(
+        "SELECT id FROM races WHERE completed = 1 ORDER BY round DESC LIMIT 1"
+    ).fetchone()
+    last_race_id = last_race["id"] if last_race else None
+
+    leaderboard = db.execute("""
+        SELECT u.id, u.username,
+               COALESCE(SUM(ss.points), 0) as total_points,
+               COALESCE((SELECT points FROM season_scores WHERE user_id = u.id AND race_id = ?), 0) as last_race_pts
+        FROM users u
+        LEFT JOIN season_scores ss ON u.id = ss.user_id
+        WHERE u.id IN (SELECT DISTINCT user_id FROM season_teams)
+        GROUP BY u.id
+        ORDER BY total_points DESC
+    """, (last_race_id,)).fetchall()
+
+    # User's season team
+    season_drivers = db.execute("""
+        SELECT d.*, st.is_turbo, st.slot
+        FROM season_teams st
+        JOIN drivers d ON st.driver_id = d.id
+        WHERE st.user_id = ? AND st.driver_id IS NOT NULL
+        ORDER BY st.slot
+    """, (user_id,)).fetchall()
+
+    season_constructors = db.execute("""
+        SELECT c.*, st.slot
+        FROM season_teams st
+        JOIN constructors c ON st.constructor_id = c.id
+        WHERE st.user_id = ? AND st.constructor_id IS NOT NULL
+    """, (user_id,)).fetchall()
+
+    has_season_team = len(season_drivers) > 0
+
+    # Last race summary
+    last_race_summary = []
+    last_race_info = None
+    if last_race_id:
+        last_race_info = db.execute("SELECT * FROM races WHERE id = ?", (last_race_id,)).fetchone()
+        users_list = db.execute("SELECT DISTINCT user_id FROM season_teams").fetchall()
+        for u in users_list:
+            uid = u["user_id"]
+            uname = db.execute("SELECT username FROM users WHERE id = ?", (uid,)).fetchone()["username"]
+            score_row = db.execute(
+                "SELECT points FROM season_scores WHERE user_id = ? AND race_id = ?",
+                (uid, last_race_id)
+            ).fetchone()
+            total_pts = score_row["points"] if score_row else 0
+            driver_picks = db.execute("""
+                SELECT d.name, ps.points, ps.is_turbo
+                FROM season_pick_scores ps
+                JOIN drivers d ON ps.driver_id = d.id
+                WHERE ps.user_id = ? AND ps.race_id = ?
+                ORDER BY ps.points DESC
+            """, (uid, last_race_id)).fetchall()
+            constructor_picks = db.execute("""
+                SELECT c.name, ps.points
+                FROM season_pick_constructor_scores ps
+                JOIN constructors c ON ps.constructor_id = c.id
+                WHERE ps.user_id = ? AND ps.race_id = ?
+            """, (uid, last_race_id)).fetchall()
+            last_race_summary.append({
+                "username": uname,
+                "total_points": total_pts,
+                "drivers": [{"name": p["name"], "points": p["points"], "is_turbo": p["is_turbo"]} for p in driver_picks],
+                "constructors": [{"name": p["name"], "points": p["points"]} for p in constructor_picks],
+            })
+        last_race_summary.sort(key=lambda x: x["total_points"], reverse=True)
+
+    return render_template(
+        "season.html",
+        leaderboard=leaderboard,
+        season_drivers=season_drivers,
+        season_constructors=season_constructors,
+        has_season_team=has_season_team,
+        last_race_summary=last_race_summary,
+        last_race_info=last_race_info,
+    )
+
+
+@app.route("/season/team", methods=["GET", "POST"])
+@login_required
+def season_team():
+    db = get_db()
+    user_id = session["user_id"]
+
+    # Check if user already has a season team
+    existing = db.execute("SELECT COUNT(*) as c FROM season_teams WHERE user_id = ?", (user_id,)).fetchone()["c"]
+    if existing:
+        flash("Your season team is already locked in.", "error")
+        return redirect(url_for("season"))
+
+    if request.method == "POST":
+        driver_ids = request.form.getlist("drivers")
+        constructor_ids = request.form.getlist("constructors")
+        turbo_driver = request.form.get("turbo_driver", "")
+
+        if len(driver_ids) != 5:
+            flash("You must select exactly 5 drivers.", "error")
+            return redirect(url_for("season_team"))
+        if len(constructor_ids) != 1:
+            flash("You must select exactly 1 constructor.", "error")
+            return redirect(url_for("season_team"))
+        if not turbo_driver:
+            flash("You must select a turbo driver.", "error")
+            return redirect(url_for("season_team"))
+
+        # Check budget
+        total_cost = 0
+        for did in driver_ids:
+            d = db.execute("SELECT price FROM drivers WHERE id = ?", (did,)).fetchone()
+            if d:
+                total_cost += d["price"]
+        for cid in constructor_ids:
+            c = db.execute("SELECT price FROM constructors WHERE id = ?", (cid,)).fetchone()
+            if c:
+                total_cost += c["price"]
+
+        if total_cost > 100.0:
+            flash("Team exceeds $100M budget.", "error")
+            return redirect(url_for("season_team"))
+
+        # Save season team
+        for i, did in enumerate(driver_ids):
+            is_turbo = 1 if did == turbo_driver else 0
+            db.execute(
+                "INSERT INTO season_teams (user_id, driver_id, is_turbo, slot) VALUES (?,?,?,?)",
+                (user_id, did, is_turbo, i + 1)
+            )
+        db.execute(
+            "INSERT INTO season_teams (user_id, constructor_id, is_turbo, slot) VALUES (?,?,0,?)",
+            (user_id, constructor_ids[0], 6)
+        )
+        db.commit()
+        flash("Season team locked in!", "success")
+        return redirect(url_for("season"))
+
+    drivers = db.execute("SELECT * FROM drivers ORDER BY price DESC").fetchall()
+    constructors = db.execute("SELECT * FROM constructors ORDER BY price DESC").fetchall()
+
+    return render_template(
+        "season_team.html",
+        drivers=drivers,
+        constructors=constructors,
+        turbo_salary_cap=TURBO_SALARY_CAP,
+    )
+
+
 @app.route("/team", methods=["GET", "POST"])
 @login_required
 def team():
@@ -1824,10 +2019,61 @@ def score_race(db, race_id, rescore=False):
     # Dynamic pricing
     update_driver_prices(db, race_id)
 
+    # Score season league
+    score_season_league(db, race_id, driver_points, constructor_points)
+
     if not rescore:
         process_lock_decrements(db, race_id)
     db.execute("UPDATE races SET completed = 1 WHERE id = ?", (race_id,))
     db.commit()
+
+
+def score_season_league(db, race_id, driver_points, constructor_points):
+    """Score the season league using fixed season teams."""
+    # Clean previous scores for this race (safe since teams never change)
+    db.execute("DELETE FROM season_scores WHERE race_id = ?", (race_id,))
+    db.execute("DELETE FROM season_pick_scores WHERE race_id = ?", (race_id,))
+    db.execute("DELETE FROM season_pick_constructor_scores WHERE race_id = ?", (race_id,))
+
+    users = db.execute("SELECT DISTINCT user_id FROM season_teams").fetchall()
+    for user in users:
+        uid = user["user_id"]
+        user_pts = 0
+
+        picks = db.execute(
+            "SELECT driver_id, is_turbo FROM season_teams WHERE user_id = ? AND driver_id IS NOT NULL",
+            (uid,)
+        ).fetchall()
+        cpicks = db.execute(
+            "SELECT constructor_id FROM season_teams WHERE user_id = ? AND constructor_id IS NOT NULL",
+            (uid,)
+        ).fetchall()
+
+        has_full_lineup = len(picks) >= 5 and len(cpicks) >= 1
+
+        for pick in picks:
+            dp = driver_points.get(pick["driver_id"], 0)
+            is_turbo = pick["is_turbo"] and has_full_lineup
+            if is_turbo:
+                dp *= 2
+            user_pts += dp
+            db.execute("""
+                INSERT INTO season_pick_scores (user_id, race_id, driver_id, points, is_turbo) VALUES (?, ?, ?, ?, ?)
+            """, (uid, race_id, pick["driver_id"], dp, int(is_turbo)))
+
+        for cpick in cpicks:
+            cname = db.execute("SELECT name FROM constructors WHERE id = ?", (cpick["constructor_id"],)).fetchone()
+            if cname:
+                cpts = constructor_points.get(cname["name"], 0)
+                user_pts += cpts
+                db.execute("""
+                    INSERT INTO season_pick_constructor_scores (user_id, race_id, constructor_id, points) VALUES (?, ?, ?, ?)
+                """, (uid, race_id, cpick["constructor_id"], cpts))
+
+        db.execute("""
+            INSERT INTO season_scores (user_id, race_id, points) VALUES (?, ?, ?)
+            ON CONFLICT(user_id, race_id) DO UPDATE SET points = ?
+        """, (uid, race_id, user_pts, user_pts))
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1034,3 +1034,37 @@ a:hover { text-decoration: underline; text-shadow: var(--text-glow); }
     box-shadow: 0 0 6px rgba(255,170,0,0.4);
 }
 .lock-btn-group .lock-btn.active + .lock-btn { border-left-color: var(--accent); }
+
+/* ── Season League Blue Theme ─────────────────────────────── */
+.season-theme {
+    --accent:    #4a9eff;
+    --accent2:   #2d7fe0;
+    --border:    rgba(74,158,255,0.2);
+    --text-dim:  #7a8ba8;
+    --gold:      #4a9eff;
+    --orange:    #4a9eff;
+    --glow-orange: 0 0 6px rgba(74,158,255,0.25);
+    --text-glow:   0 0 4px rgba(74,158,255,0.3);
+}
+
+.season-theme .navbar {
+    border-bottom-color: var(--accent);
+}
+
+.season-theme .turbo-badge {
+    background: var(--accent);
+}
+
+.season-theme .race-summary-pick-pts {
+    color: var(--accent);
+}
+
+.season-theme .picker-card.selected {
+    border-color: var(--accent);
+    background: rgba(74,158,255,.06);
+    box-shadow: inset 0 0 20px rgba(74,158,255,.05), var(--glow-orange);
+}
+
+.season-theme .budget-bar .budget-remaining.over {
+    color: var(--danger);
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1068,3 +1068,125 @@ a:hover { text-decoration: underline; text-shadow: var(--text-glow); }
 .season-theme .budget-bar .budget-remaining.over {
     color: var(--danger);
 }
+
+/* ── Hamburger Menu ───────────────────────────────────────── */
+.hamburger {
+    display: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: .5rem;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.hamburger span {
+    display: block;
+    width: 22px;
+    height: 2px;
+    background: var(--accent);
+    transition: all .2s;
+}
+
+.bug-btn {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    background: var(--accent);
+    color: #000;
+    border: none;
+    padding: .75rem 1.5rem;
+    border-radius: 10px;
+    font-weight: 700;
+    cursor: pointer;
+    font-size: 1rem;
+    z-index: 999;
+}
+
+/* ── Mobile: 768px ────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .hamburger {
+        display: flex;
+    }
+
+    .navbar {
+        flex-wrap: wrap;
+    }
+
+    .navbar nav {
+        display: none;
+        width: 100%;
+        flex-direction: column;
+        gap: 0;
+        padding-top: .75rem;
+    }
+
+    .navbar.open nav {
+        display: flex;
+    }
+
+    .navbar nav a {
+        padding: .75rem 0;
+        border-top: 1px solid var(--border);
+        font-size: 1rem;
+    }
+
+    .bug-btn {
+        padding: .5rem 1rem;
+        font-size: .85rem;
+        bottom: 1rem;
+        right: 1rem;
+    }
+
+    .btn-primary {
+        max-width: none !important;
+        width: 100%;
+    }
+
+    .budget-bar {
+        flex-direction: column;
+        gap: .5rem;
+        text-align: center;
+        top: 56px;
+    }
+
+    .lock-btn-group .lock-btn {
+        width: 36px;
+        height: 36px;
+        font-size: .8rem;
+    }
+
+    .picker-card:hover {
+        border-color: var(--border);
+        box-shadow: none;
+    }
+    .picker-card:active,
+    .picker-card.selected {
+        border-color: var(--accent);
+    }
+
+    .scroll-area {
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+/* ── Mobile: 480px ────────────────────────────────────────── */
+@media (max-width: 480px) {
+    .container { padding: .75rem; }
+
+    .card { padding: 1rem; }
+
+    .stat-card .stat-value { font-size: 1.5rem; }
+
+    .dashboard { grid-template-columns: 1fr; gap: 1rem; }
+
+    .picker-grid { grid-template-columns: 1fr; }
+
+    .portrait-md { width: 44px; height: 44px; }
+
+    .countdown-unit { min-width: 36px; }
+    .cd-value { font-size: 1.25rem; }
+
+    .race-item { font-size: .8rem; }
+    .race-item .race-date { font-size: .75rem; }
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -6,6 +6,7 @@
     <nav>
         <a href="{{ url_for('home') }}">Dashboard</a>
         <a href="{{ url_for('team') }}">My Team</a>
+        <a href="{{ url_for('season') }}">Season League</a>
         <a href="{{ url_for('admin') }}" class="active">Admin</a>
         <a href="{{ url_for('logout') }}">Logout</a>
     </nav>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,17 +1,7 @@
 {% extends "base.html" %}
+{% set active_page = 'admin' %}
 {% block title %}Admin - F1 Fantasy{% endblock %}
 {% block body %}
-<header class="navbar">
-    <span class="brand">F1 Fantasy</span>
-    <nav>
-        <a href="{{ url_for('home') }}">Dashboard</a>
-        <a href="{{ url_for('team') }}">My Team</a>
-        <a href="{{ url_for('season') }}">Season League</a>
-        <a href="{{ url_for('admin') }}" class="active">Admin</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-    </nav>
-</header>
-
 <div class="container">
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
@@ -196,56 +186,5 @@
         </form>
     </div>
 
-    <!-- Scoring Rules Reference -->
-    <div class="card" style="margin-top: 1.5rem;">
-        <h2>Scoring Rules</h2>
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1.5rem; font-size: .9rem;">
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Race Finish</h4>
-                <div>P1: 100 &bull; P2: 97 &bull; P3: 94</div>
-                <div>-3 per position (P22: 37)</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Qualifying</h4>
-                <div>P1: 50 &bull; P2: 48 &bull; P3: 46</div>
-                <div>-2 per position (P22: 8)</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Sprint Race</h4>
-                <div>P1: 20 &bull; P2: 19 &bull; P3: 18</div>
-                <div>-1 per position (P20: 1)</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Overtakes</h4>
-                <div>+3 pts per position gained</div>
-                <div>(quali position vs race finish)</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Teammate Battle</h4>
-                <div>Beat by 1-3: +2 &bull; 4-7: +5</div>
-                <div>Beat by 8-12: +8 &bull; 13+: +12</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Completion</h4>
-                <div>25%: 3 &bull; 50%: 6 &bull; 75%: 9 &bull; 90%: 12</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">PI Points</h4>
-                <div>8-race avg vs finish (needs 8 races)</div>
-                <div>+1 better: 2 &bull; +4: 9 &bull; +8: 25 &bull; +9: 30</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Constructors</h4>
-                <div>Race: each driver mapped (P1=60, -2/pos), summed</div>
-                <div>Quali: each driver mapped (P1=30, -1/pos), summed</div>
-            </div>
-            <div>
-                <h4 style="color: var(--text-dim); margin-bottom: .5rem;">Special</h4>
-                <div>Turbo Driver: 2x all points</div>
-                <div>Dynamic pricing after each race</div>
-                <div>Driver Lock: 1-5 races, then cooldown</div>
-            </div>
-        </div>
-    </div>
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,15 +8,32 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
+    {% block navbar %}
+    <header class="navbar">
+        <span class="brand">F1 Fantasy</span>
+        <button class="hamburger" onclick="this.closest('.navbar').classList.toggle('open')" aria-label="Menu">
+            <span></span><span></span><span></span>
+        </button>
+        <nav>
+            <a href="{{ url_for('home') }}" class="{% if active_page == 'home' %}active{% endif %}">Dashboard</a>
+            <a href="{{ url_for('team') }}" class="{% if active_page == 'team' %}active{% endif %}">My Team</a>
+            <a href="{{ url_for('season') }}" class="{% if active_page == 'season' %}active{% endif %}">Season League</a>
+            <a href="{{ url_for('admin') }}" class="{% if active_page == 'admin' %}active{% endif %}">Admin</a>
+            <a href="{{ url_for('logout') }}">Logout</a>
+        </nav>
+    </header>
+    {% endblock %}
+
     {% block body %}{% endblock %}
 
     <!-- Bug Report -->
-    <button id="bugBtn" style="position:fixed;bottom:1.5rem;right:1.5rem;background:var(--accent);color:#000;border:none;padding:.75rem 1.5rem;border-radius:10px;font-weight:700;cursor:pointer;font-size:1rem;z-index:999;">Report a Bug</button>
+    <button id="bugBtn" class="bug-btn">Report a Bug</button>
     <div id="bugModal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);z-index:1000;align-items:center;justify-content:center;">
         <div style="text-align:center;cursor:pointer;" onclick="document.getElementById('bugModal').style.display='none'">
             <img src="{{ url_for('static', filename='img/bug.jpg') }}" style="max-width:90vw;max-height:70vh;border-radius:12px;">
             <p style="color:#fff;font-size:2rem;font-weight:800;margin-top:1rem;">get fuked</p>
+            <p style="color:var(--danger, #e6333f);font-size:1rem;font-weight:600;margin-top:.5rem;">10 points has been deducted from your score</p>
         </div>
     </div>
     <script>

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,6 +6,7 @@
     <nav>
         <a href="{{ url_for('home') }}" class="active">Dashboard</a>
         <a href="{{ url_for('team') }}">My Team</a>
+        <a href="{{ url_for('season') }}">Season League</a>
         <a href="{{ url_for('admin') }}">Admin</a>
         <a href="{{ url_for('logout') }}">Logout</a>
     </nav>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,17 +1,7 @@
 {% extends "base.html" %}
+{% set active_page = 'home' %}
 {% block title %}Dashboard - F1 Fantasy{% endblock %}
 {% block body %}
-<header class="navbar">
-    <span class="brand">F1 Fantasy</span>
-    <nav>
-        <a href="{{ url_for('home') }}" class="active">Dashboard</a>
-        <a href="{{ url_for('team') }}">My Team</a>
-        <a href="{{ url_for('season') }}">Season League</a>
-        <a href="{{ url_for('admin') }}">Admin</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-    </nav>
-</header>
-
 <div class="container">
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
@@ -269,6 +259,7 @@
         <!-- Constructor Standings (Official F1) -->
         <div class="card">
             <h2>Constructor Standings <span style="font-size:.7rem; color:var(--text-dim); font-weight:400;">Official F1</span></h2>
+            <div class="table-scroll">
             <table class="standings-table">
                 <thead>
                     <tr><th>#</th><th>Constructor</th><th class="points-col">Pts</th></tr>
@@ -286,6 +277,7 @@
                     {% endif %}
                 </tbody>
             </table>
+            </div>
         </div>
 
         <!-- Race Calendar -->

--- a/templates/race_picks.html
+++ b/templates/race_picks.html
@@ -1,17 +1,7 @@
 {% extends "base.html" %}
+{% set active_page = 'team' %}
 {% block title %}Picks - {{ race.name }} - F1 Fantasy{% endblock %}
 {% block body %}
-<header class="navbar">
-    <span class="brand">F1 Fantasy</span>
-    <nav>
-        <a href="{{ url_for('home') }}">Dashboard</a>
-        <a href="{{ url_for('team') }}">My Team</a>
-        <a href="{{ url_for('season') }}">Season League</a>
-        <a href="{{ url_for('admin') }}">Admin</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-    </nav>
-</header>
-
 <div class="container">
     <div class="retro-header">
         <h1>R{{ race.round }} {{ race.name }}</h1>

--- a/templates/season.html
+++ b/templates/season.html
@@ -1,18 +1,8 @@
 {% extends "base.html" %}
+{% set active_page = 'season' %}
+{% block body_class %}season-theme{% endblock %}
 {% block title %}Season League - F1 Fantasy{% endblock %}
 {% block body %}
-<div class="season-theme">
-<header class="navbar">
-    <span class="brand">F1 Fantasy</span>
-    <nav>
-        <a href="{{ url_for('home') }}">Dashboard</a>
-        <a href="{{ url_for('team') }}">My Team</a>
-        <a href="{{ url_for('season') }}" class="active">Season League</a>
-        <a href="{{ url_for('admin') }}">Admin</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-    </nav>
-</header>
-
 <div class="container">
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
@@ -154,6 +144,5 @@
         </div>
         {% endif %}
     </div>
-</div>
 </div>
 {% endblock %}

--- a/templates/season.html
+++ b/templates/season.html
@@ -75,11 +75,13 @@
                 <!-- Turbo selector -->
                 {% if not lineup_locked %}
                 <form method="POST" style="margin-top: 1rem; padding: .75rem; background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius);">
-                    <label style="font-size: .85rem; font-weight: 600; color: var(--text-dim); display: block; margin-bottom: .4rem;">Change Turbo Driver</label>
+                    <label style="font-size: .85rem; font-weight: 600; color: var(--text-dim); display: block; margin-bottom: .4rem;">Change Turbo Driver <span style="font-weight:400;">(under ${{ "%.1f"|format(turbo_salary_cap) }}M)</span></label>
                     <div style="display: flex; gap: .5rem; align-items: center;">
                         <select name="turbo_driver" style="flex: 1; padding: .5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text); font-size: .9rem;">
                             {% for d in season_drivers %}
-                            <option value="{{ d.id }}" {{ 'selected' if turbo_id == d.id|string }}>{{ d.name }}</option>
+                            {% if d.price < turbo_salary_cap %}
+                            <option value="{{ d.id }}" {{ 'selected' if turbo_id == d.id|string }}>{{ d.name }} (${{ "%.1f"|format(d.price) }}M)</option>
+                            {% endif %}
                             {% endfor %}
                         </select>
                         <button type="submit" class="btn btn-primary" style="width: auto; padding: .5rem 1rem; font-size: .85rem;">Update</button>

--- a/templates/season.html
+++ b/templates/season.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+{% block title %}Season League - F1 Fantasy{% endblock %}
+{% block body %}
+<header class="navbar">
+    <span class="brand">F1 Fantasy</span>
+    <nav>
+        <a href="{{ url_for('home') }}">Dashboard</a>
+        <a href="{{ url_for('team') }}">My Team</a>
+        <a href="{{ url_for('season') }}" class="active">Season League</a>
+        <a href="{{ url_for('admin') }}">Admin</a>
+        <a href="{{ url_for('logout') }}">Logout</a>
+    </nav>
+</header>
+
+<div class="container">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+    <div class="flash {{ category }}">{{ message }}</div>
+    {% endfor %}
+    {% endwith %}
+
+    <div class="dashboard">
+        <!-- Leaderboard -->
+        <div class="card full-width">
+            <h2>Season League Leaderboard</h2>
+            {% if leaderboard %}
+            <div class="table-scroll">
+            <table class="leaderboard-table">
+                <thead>
+                    <tr>
+                        <th class="rank">#</th>
+                        <th>Player</th>
+                        <th class="points-col hide-narrow">Last Race</th>
+                        <th class="points-col">Points</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in leaderboard %}
+                    <tr class="{{ 'current-user' if row.id == session.user_id }}">
+                        <td class="rank {{ 'gold' if loop.index == 1 }}{{ 'silver' if loop.index == 2 }}{{ 'bronze' if loop.index == 3 }}">
+                            {{ loop.index }}
+                        </td>
+                        <td>{{ row.username }}</td>
+                        <td class="points-col hide-narrow" style="color: var(--text-dim);">{{ row.last_race_pts }}</td>
+                        <td class="points-col">{{ row.total_points }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            </div>
+            {% else %}
+            <p style="color: var(--text-dim); text-align: center; padding: 1rem;">No season teams picked yet.</p>
+            {% endif %}
+        </div>
+
+        <!-- My Season Team -->
+        <div class="card">
+            <h2>My Season Team</h2>
+            {% if has_season_team %}
+                {% for d in season_drivers %}
+                <div class="team-slot">
+                    <div class="team-slot-left">
+                        <img class="portrait-sm" src="{{ url_for('static', filename='img/portraits/' + d.name.lower().replace(' ', '-').replace('.', '') + '.webp') }}" alt="{{ d.name }}">
+                        <div>
+                            <span class="driver-name">{{ d.name }}</span>
+                            {% if d.is_turbo %}<span class="turbo-badge">2x</span>{% endif %}
+                            <br><span class="driver-team">{{ d.team }}</span>
+                        </div>
+                    </div>
+                    <span class="driver-price">${{ "%.1f"|format(d.price) }}M</span>
+                </div>
+                {% endfor %}
+                {% for c in season_constructors %}
+                <div class="team-slot">
+                    <div class="team-slot-left">
+                        <img class="portrait-sm" style="object-fit: contain;" src="{{ url_for('static', filename='img/constructors/' + c.name.lower().replace(' ', '-') + '.webp') }}" alt="{{ c.name }}">
+                        <div>
+                            <span class="driver-name">{{ c.name }}</span>
+                            <br><span class="driver-team">Constructor</span>
+                        </div>
+                    </div>
+                    <span class="driver-price">${{ "%.1f"|format(c.price) }}M</span>
+                </div>
+                {% endfor %}
+            {% else %}
+                <div class="empty-team">
+                    <p>You haven't picked a season team yet.</p>
+                    <p style="color: var(--text-dim); font-size: .85rem; margin: .5rem 0;">This team is permanent for the entire season.</p>
+                    <br>
+                    <a href="{{ url_for('season_team') }}" class="btn btn-primary" style="display:inline-flex; width:auto;">Pick Season Team</a>
+                </div>
+            {% endif %}
+        </div>
+
+        <!-- Last Race Summary -->
+        {% if last_race_summary %}
+        <div class="card full-width">
+            <h2>Last Race Summary <span style="font-size:.7rem; color:var(--text-dim); font-weight:400;">{{ last_race_info.name }}</span></h2>
+            <div class="scroll-area">
+                {% for entry in last_race_summary %}
+                <div class="race-summary-card">
+                    <div class="race-summary-header">
+                        <div class="race-summary-user">
+                            <span class="race-summary-rank">{{ loop.index }}</span>
+                            <strong>{{ entry.username }}</strong>
+                        </div>
+                        <span class="race-summary-total">{{ entry.total_points }} pts</span>
+                    </div>
+                    {% if entry.drivers or entry.constructors %}
+                    <div class="race-summary-picks">
+                        {% for d in entry.drivers %}
+                        <div class="race-summary-pick">
+                            <img class="portrait-xs" src="{{ url_for('static', filename='img/portraits/' + d.name.lower().replace(' ', '-').replace('.', '') + '.webp') }}" alt="{{ d.name }}">
+                            <div class="race-summary-pick-info">
+                                <span class="race-summary-pick-name">
+                                    {{ d.name }}{% if d.is_turbo %} <span class="turbo-badge" style="font-size:.55rem;">2x</span>{% endif %}
+                                </span>
+                                <span class="race-summary-pick-pts">{{ d.points }}</span>
+                            </div>
+                        </div>
+                        {% endfor %}
+                        {% for c in entry.constructors %}
+                        <div class="race-summary-pick constructor">
+                            <img class="portrait-xs" style="object-fit: contain;" src="{{ url_for('static', filename='img/constructors/' + c.name.lower().replace(' ', '-') + '.webp') }}" alt="{{ c.name }}">
+                            <div class="race-summary-pick-info">
+                                <span class="race-summary-pick-name">{{ c.name }}</span>
+                                <span class="race-summary-pick-pts">{{ c.points }}</span>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/season.html
+++ b/templates/season.html
@@ -81,6 +81,25 @@
                     </div>
                 </div>
                 {% endfor %}
+
+                <!-- Turbo selector -->
+                {% if not lineup_locked %}
+                <form method="POST" style="margin-top: 1rem; padding: .75rem; background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius);">
+                    <label style="font-size: .85rem; font-weight: 600; color: var(--text-dim); display: block; margin-bottom: .4rem;">Change Turbo Driver</label>
+                    <div style="display: flex; gap: .5rem; align-items: center;">
+                        <select name="turbo_driver" style="flex: 1; padding: .5rem; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text); font-size: .9rem;">
+                            {% for d in season_drivers %}
+                            <option value="{{ d.id }}" {{ 'selected' if turbo_id == d.id|string }}>{{ d.name }}</option>
+                            {% endfor %}
+                        </select>
+                        <button type="submit" class="btn btn-primary" style="width: auto; padding: .5rem 1rem; font-size: .85rem;">Update</button>
+                    </div>
+                </form>
+                {% else %}
+                <div style="margin-top: .75rem; padding: .5rem .75rem; background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius); font-size: .8rem; color: var(--text-dim);">
+                    Turbo locked until race is scored
+                </div>
+                {% endif %}
             {% else %}
                 <div class="empty-team">
                     <p>You haven't picked a season team yet.</p>

--- a/templates/season.html
+++ b/templates/season.html
@@ -68,7 +68,6 @@
                             <br><span class="driver-team">{{ d.team }}</span>
                         </div>
                     </div>
-                    <span class="driver-price">${{ "%.1f"|format(d.price) }}M</span>
                 </div>
                 {% endfor %}
                 {% for c in season_constructors %}
@@ -80,7 +79,6 @@
                             <br><span class="driver-team">Constructor</span>
                         </div>
                     </div>
-                    <span class="driver-price">${{ "%.1f"|format(c.price) }}M</span>
                 </div>
                 {% endfor %}
             {% else %}

--- a/templates/season.html
+++ b/templates/season.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Season League - F1 Fantasy{% endblock %}
 {% block body %}
+<div class="season-theme">
 <header class="navbar">
     <span class="brand">F1 Fantasy</span>
     <nav>
@@ -136,5 +137,6 @@
         </div>
         {% endif %}
     </div>
+</div>
 </div>
 {% endblock %}

--- a/templates/season_team.html
+++ b/templates/season_team.html
@@ -25,13 +25,7 @@
     </div>
 
     <form method="POST">
-        <!-- Budget Bar -->
         <div class="budget-bar">
-            <div class="budget-info">
-                Budget: <span id="budgetSpent">$0.0M</span> / $100.0M
-                &nbsp;&middot;&nbsp;
-                Remaining: <span id="budgetRemaining" class="budget-remaining">$100.0M</span>
-            </div>
             <div>
                 Drivers: <span id="driverCount">0</span>/5
                 &nbsp;&middot;&nbsp;
@@ -54,7 +48,6 @@
                             <div class="points-tag">{{ d.points }} pts</div>
                         </div>
                     </div>
-                    <div class="price-tag">${{ "%.1f"|format(d.price) }}M</div>
                 </label>
                 {% endfor %}
             </div>
@@ -75,7 +68,6 @@
                         <div class="points-tag">{{ c.points }} pts</div>
                     </div>
                     </div>
-                    <div class="price-tag">${{ "%.1f"|format(c.price) }}M</div>
                 </label>
                 {% endfor %}
             </div>
@@ -85,7 +77,7 @@
         <div class="turbo-select">
             <h3 style="margin-bottom: .75rem;">Turbo Driver (2x points)</h3>
             <p style="color: var(--text-dim); font-size: .85rem; margin-bottom: 1rem;">
-                Choose one of your selected drivers to receive double points. Only drivers under ${{ "%.1f"|format(turbo_salary_cap) }}M are eligible.
+                Choose one of your selected drivers to receive double points.
             </p>
             <select name="turbo_driver" id="turboSelect" class="form-group" style="width: 100%; padding: .75rem 1rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 1rem;">
                 <option value="">-- Select turbo driver --</option>
@@ -102,26 +94,9 @@
 
 {% block scripts %}
 <script>
-const budget = 100.0;
-const turboSalaryCap = {{ turbo_salary_cap }};
-
 function updateUI() {
     const driverChecks = document.querySelectorAll('input[name="drivers"]:checked');
     const constructorChecks = document.querySelectorAll('input[name="constructors"]:checked');
-
-    let spent = 0;
-    driverChecks.forEach(cb => {
-        spent += parseFloat(cb.closest('.picker-card').dataset.price);
-    });
-    constructorChecks.forEach(cb => {
-        spent += parseFloat(cb.closest('.picker-card').dataset.price);
-    });
-
-    const remaining = budget - spent;
-    document.getElementById('budgetSpent').textContent = `$${spent.toFixed(1)}M`;
-    const remEl = document.getElementById('budgetRemaining');
-    remEl.textContent = `$${remaining.toFixed(1)}M`;
-    remEl.className = remaining < 0 ? 'budget-remaining over' : 'budget-remaining';
 
     document.getElementById('driverCount').textContent = driverChecks.length;
     document.getElementById('constructorCount').textContent = constructorChecks.length;
@@ -131,12 +106,10 @@ function updateUI() {
     turboSelect.innerHTML = '<option value="">-- Select turbo driver --</option>';
     driverChecks.forEach(cb => {
         const card = cb.closest('.picker-card');
-        const price = parseFloat(card.dataset.price);
         const name = card.querySelector('h4').textContent;
-        if (price >= turboSalaryCap) return;
         const opt = document.createElement('option');
         opt.value = cb.value;
-        opt.textContent = name + ` ($${price.toFixed(1)}M)`;
+        opt.textContent = name;
         if (cb.value === currentTurbo) opt.selected = true;
         turboSelect.appendChild(opt);
     });
@@ -154,7 +127,6 @@ function updateUI() {
     if (driverChecks.length < 5) hints.push(`${5 - driverChecks.length} more driver${5 - driverChecks.length !== 1 ? 's' : ''}`);
     if (constructorChecks.length < 1) hints.push('1 constructor');
     if (!hasTurbo) hints.push('a turbo driver');
-    if (remaining < 0) hints.push('under budget');
 
     if (hints.length === 0) {
         saveBtn.disabled = false;

--- a/templates/season_team.html
+++ b/templates/season_team.html
@@ -1,66 +1,56 @@
 {% extends "base.html" %}
-{% block title %}Picks - {{ race.name }} - F1 Fantasy{% endblock %}
+{% block title %}Pick Season Team - F1 Fantasy{% endblock %}
 {% block body %}
 <header class="navbar">
     <span class="brand">F1 Fantasy</span>
     <nav>
         <a href="{{ url_for('home') }}">Dashboard</a>
         <a href="{{ url_for('team') }}">My Team</a>
-        <a href="{{ url_for('season') }}">Season League</a>
+        <a href="{{ url_for('season') }}" class="active">Season League</a>
         <a href="{{ url_for('admin') }}">Admin</a>
         <a href="{{ url_for('logout') }}">Logout</a>
     </nav>
 </header>
 
 <div class="container">
-    <div class="retro-header">
-        <h1>R{{ race.round }} {{ race.name }}</h1>
-        <p>Submit your driver and constructor picks for this race</p>
-    </div>
-
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
     <div class="flash {{ category }}">{{ message }}</div>
     {% endfor %}
     {% endwith %}
 
-    <form method="POST" id="teamForm">
-        <!-- Budget bar -->
+    <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(255,170,0,0.08); border: 1px solid var(--accent); border-radius: var(--radius); text-align: center;">
+        <strong style="color: var(--accent);">This team is permanent for the entire season. Choose wisely.</strong>
+    </div>
+
+    <form method="POST">
+        <!-- Budget Bar -->
         <div class="budget-bar">
             <div class="budget-info">
-                Budget: <span id="budgetSpent">$0.0M</span> / ${{ "%.1f"|format(budget) }}M
+                Budget: <span id="budgetSpent">$0.0M</span> / $100.0M
+                &nbsp;&middot;&nbsp;
+                Remaining: <span id="budgetRemaining" class="budget-remaining">$100.0M</span>
             </div>
             <div>
-                Remaining: <span class="budget-remaining" id="budgetRemaining">${{ "%.1f"|format(budget) }}M</span>
+                Drivers: <span id="driverCount">0</span>/5
+                &nbsp;&middot;&nbsp;
+                Constructors: <span id="constructorCount">0</span>/1
             </div>
         </div>
 
         <!-- Drivers -->
         <div class="picker-section">
             <h3>Select 5 Drivers</h3>
-            <p style="color: var(--text-dim); font-size: .85rem; margin-bottom: 1rem;">
-                Selected: <span id="driverCount">0</span>/5
-                &nbsp;&middot;&nbsp; Lock a driver for 1-5 races. After their lock expires, they're unavailable for 1 race.
-            </p>
             <div class="picker-grid">
                 {% for d in drivers %}
-                <label class="picker-card {{ 'selected' if d.id|string in selected_driver_ids }}" data-price="{{ d.price }}" data-type="driver">
-                    <input type="checkbox" name="drivers" value="{{ d.id }}"
-                           {{ 'checked' if d.id|string in selected_driver_ids }}>
+                <label class="picker-card" data-price="{{ d.price }}" data-type="driver">
+                    <input type="checkbox" name="drivers" value="{{ d.id }}">
                     <div class="picker-card-inner">
                         <img class="portrait-md" src="{{ url_for('static', filename='img/portraits/' + d.name.lower().replace(' ', '-').replace('.', '') + '.webp') }}" alt="{{ d.name }}">
                         <div class="driver-info">
                             <h4>#{{ d.number }} {{ d.name }}</h4>
                             <div class="team-name">{{ d.team }}</div>
                             <div class="points-tag">{{ d.points }} pts</div>
-                            <div class="lock-select" style="margin-top: .4rem;">
-                                <input type="hidden" name="lock_{{ d.id }}" value="{{ driver_locks.get(d.id|string, 1) }}" class="lock-val">
-                                <div class="lock-btn-group" onclick="event.stopPropagation(); event.preventDefault();">
-                                    {% for n in range(1, 6) %}
-                                    <button type="button" class="lock-btn{{ ' active' if driver_locks.get(d.id|string, 1) == n }}" data-n="{{ n }}" onclick="setLock(this)">{{ n }}</button>
-                                    {% endfor %}
-                                </div>
-                            </div>
                         </div>
                     </div>
                     <div class="price-tag">${{ "%.1f"|format(d.price) }}M</div>
@@ -72,29 +62,16 @@
         <!-- Constructors -->
         <div class="picker-section">
             <h3>Select 1 Constructor</h3>
-            <p style="color: var(--text-dim); font-size: .85rem; margin-bottom: 1rem;">
-                Selected: <span id="constructorCount">0</span>/1
-                &nbsp;&middot;&nbsp; Lock a constructor for 1-5 races. After their lock expires, they're unavailable for 1 race.
-            </p>
             <div class="picker-grid">
                 {% for c in constructors %}
-                <label class="picker-card {{ 'selected' if c.id|string in selected_constructor_ids }}" data-price="{{ c.price }}" data-type="constructor">
-                    <input type="checkbox" name="constructors" value="{{ c.id }}"
-                           {{ 'checked' if c.id|string in selected_constructor_ids }}>
+                <label class="picker-card" data-price="{{ c.price }}" data-type="constructor">
+                    <input type="checkbox" name="constructors" value="{{ c.id }}">
                     <div class="constructor-bar" style="background: {{ c.color }};"></div>
                     <div class="picker-card-inner">
                         <img class="constructor-logo" src="{{ url_for('static', filename='img/constructors/' + c.name.lower().replace(' ', '-') + '.webp') }}" alt="{{ c.name }}">
                     <div class="driver-info">
                         <h4>{{ c.name }}</h4>
                         <div class="points-tag">{{ c.points }} pts</div>
-                        <div class="lock-select" style="margin-top: .4rem;">
-                            <input type="hidden" name="lock_c_{{ c.id }}" value="{{ constructor_locks.get(c.id|string, 1) }}" class="lock-val">
-                            <div class="lock-btn-group" onclick="event.stopPropagation(); event.preventDefault();">
-                                {% for n in range(1, 6) %}
-                                <button type="button" class="lock-btn{{ ' active' if constructor_locks.get(c.id|string, 1) == n }}" data-n="{{ n }}" onclick="setLock(this)">{{ n }}</button>
-                                {% endfor %}
-                            </div>
-                        </div>
                     </div>
                     </div>
                     <div class="price-tag">${{ "%.1f"|format(c.price) }}M</div>
@@ -115,7 +92,7 @@
         </div>
 
         <br>
-        <button type="submit" class="btn btn-primary" id="saveBtn" style="max-width: 300px;" disabled>Save Picks for {{ race.name }}</button>
+        <button type="submit" class="btn btn-primary" id="saveBtn" style="max-width: 300px;" disabled>Lock In Season Team</button>
         <p id="saveHint" style="color: var(--text-dim); font-size: .85rem; margin-top: .5rem;"></p>
     </form>
 </div>
@@ -123,16 +100,8 @@
 
 {% block scripts %}
 <script>
-const budget = {{ budget }};
-const turboId = {{ turbo_id|tojson }};
+const budget = 100.0;
 const turboSalaryCap = {{ turbo_salary_cap }};
-
-function setLock(btn) {
-    const group = btn.closest('.lock-btn-group');
-    group.querySelectorAll('.lock-btn').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    group.parentElement.querySelector('.lock-val').value = btn.dataset.n;
-}
 
 function updateUI() {
     const driverChecks = document.querySelectorAll('input[name="drivers"]:checked');
@@ -155,7 +124,6 @@ function updateUI() {
     document.getElementById('driverCount').textContent = driverChecks.length;
     document.getElementById('constructorCount').textContent = constructorChecks.length;
 
-    // Update turbo select (only drivers under salary cap are eligible)
     const turboSelect = document.getElementById('turboSelect');
     const currentTurbo = turboSelect.value;
     turboSelect.innerHTML = '<option value="">-- Select turbo driver --</option>';
@@ -167,7 +135,7 @@ function updateUI() {
         const opt = document.createElement('option');
         opt.value = cb.value;
         opt.textContent = name + ` ($${price.toFixed(1)}M)`;
-        if (cb.value === currentTurbo || cb.value === turboId) opt.selected = true;
+        if (cb.value === currentTurbo) opt.selected = true;
         turboSelect.appendChild(opt);
     });
 
@@ -176,7 +144,7 @@ function updateUI() {
         card.classList.toggle('selected', cb.checked);
     });
 
-    // Validate full lineup + turbo before allowing save
+    // Validate
     const saveBtn = document.getElementById('saveBtn');
     const saveHint = document.getElementById('saveHint');
     const hasTurbo = turboSelect.value !== '';

--- a/templates/season_team.html
+++ b/templates/season_team.html
@@ -67,7 +67,7 @@
         <div class="turbo-select">
             <h3 style="margin-bottom: .75rem;">Turbo Driver (2x points)</h3>
             <p style="color: var(--text-dim); font-size: .85rem; margin-bottom: 1rem;">
-                Choose one of your selected drivers to receive double points.
+                Choose one of your selected drivers to receive double points. Only drivers under ${{ "%.1f"|format(turbo_salary_cap) }}M are eligible.
             </p>
             <select name="turbo_driver" id="turboSelect" class="form-group" style="width: 100%; padding: .75rem 1rem; background: var(--surface2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 1rem;">
                 <option value="">-- Select turbo driver --</option>
@@ -83,6 +83,8 @@
 
 {% block scripts %}
 <script>
+const turboSalaryCap = {{ turbo_salary_cap }};
+
 function updateUI() {
     const driverChecks = document.querySelectorAll('input[name="drivers"]:checked');
     const constructorChecks = document.querySelectorAll('input[name="constructors"]:checked');
@@ -95,10 +97,12 @@ function updateUI() {
     turboSelect.innerHTML = '<option value="">-- Select turbo driver --</option>';
     driverChecks.forEach(cb => {
         const card = cb.closest('.picker-card');
+        const price = parseFloat(card.dataset.price);
+        if (price >= turboSalaryCap) return;
         const name = card.querySelector('h4').textContent;
         const opt = document.createElement('option');
         opt.value = cb.value;
-        opt.textContent = name;
+        opt.textContent = name + ` ($${price.toFixed(1)}M)`;
         if (cb.value === currentTurbo) opt.selected = true;
         turboSelect.appendChild(opt);
     });

--- a/templates/season_team.html
+++ b/templates/season_team.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Pick Season Team - F1 Fantasy{% endblock %}
 {% block body %}
+<div class="season-theme">
 <header class="navbar">
     <span class="brand">F1 Fantasy</span>
     <nav>
@@ -19,7 +20,7 @@
     {% endfor %}
     {% endwith %}
 
-    <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(255,170,0,0.08); border: 1px solid var(--accent); border-radius: var(--radius); text-align: center;">
+    <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(74,158,255,0.08); border: 1px solid var(--accent); border-radius: var(--radius); text-align: center;">
         <strong style="color: var(--accent);">This team is permanent for the entire season. Choose wisely.</strong>
     </div>
 
@@ -95,6 +96,7 @@
         <button type="submit" class="btn btn-primary" id="saveBtn" style="max-width: 300px;" disabled>Lock In Season Team</button>
         <p id="saveHint" style="color: var(--text-dim); font-size: .85rem; margin-top: .5rem;"></p>
     </form>
+</div>
 </div>
 {% endblock %}
 

--- a/templates/season_team.html
+++ b/templates/season_team.html
@@ -1,18 +1,8 @@
 {% extends "base.html" %}
+{% set active_page = 'season' %}
+{% block body_class %}season-theme{% endblock %}
 {% block title %}Pick Season Team - F1 Fantasy{% endblock %}
 {% block body %}
-<div class="season-theme">
-<header class="navbar">
-    <span class="brand">F1 Fantasy</span>
-    <nav>
-        <a href="{{ url_for('home') }}">Dashboard</a>
-        <a href="{{ url_for('team') }}">My Team</a>
-        <a href="{{ url_for('season') }}" class="active">Season League</a>
-        <a href="{{ url_for('admin') }}">Admin</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-    </nav>
-</header>
-
 <div class="container">
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}
@@ -88,7 +78,6 @@
         <button type="submit" class="btn btn-primary" id="saveBtn" style="max-width: 300px;" disabled>Lock In Season Team</button>
         <p id="saveHint" style="color: var(--text-dim); font-size: .85rem; margin-top: .5rem;"></p>
     </form>
-</div>
 </div>
 {% endblock %}
 

--- a/templates/team.html
+++ b/templates/team.html
@@ -6,6 +6,7 @@
     <nav>
         <a href="{{ url_for('home') }}">Dashboard</a>
         <a href="{{ url_for('team') }}" class="active">My Team</a>
+        <a href="{{ url_for('season') }}">Season League</a>
         <a href="{{ url_for('admin') }}">Admin</a>
         <a href="{{ url_for('logout') }}">Logout</a>
     </nav>

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,17 +1,7 @@
 {% extends "base.html" %}
+{% set active_page = 'team' %}
 {% block title %}Pick Team - F1 Fantasy{% endblock %}
 {% block body %}
-<header class="navbar">
-    <span class="brand">F1 Fantasy</span>
-    <nav>
-        <a href="{{ url_for('home') }}">Dashboard</a>
-        <a href="{{ url_for('team') }}" class="active">My Team</a>
-        <a href="{{ url_for('season') }}">Season League</a>
-        <a href="{{ url_for('admin') }}">Admin</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-    </nav>
-</header>
-
 <div class="container">
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% for category, message in messages %}


### PR DESCRIPTION
## Summary
New parallel "Season League" where users pick a permanent team that scores every race, plus mobile-friendly responsive design and blue colour theme.

### Season League
- Users pick 5 drivers + 1 constructor + 1 turbo driver (one time only, no budget cap)
- That lineup scores every race automatically when admin scores the main league
- Own leaderboard and last race summary with driver portraits and constructor logos
- Turbo driver can be changed between races (locked during quali → scoring)
- Completely separate from the main Contracts league (separate DB tables and scoring)

### Mobile-Friendly Design
- Refactored navbar into `base.html` (was duplicated across 6 templates)
- Hamburger menu on screens below 768px with slide-down nav links
- 768px breakpoint: single-column dashboard, stacked budget bar, 36px lock buttons for touch targets
- 480px breakpoint: tighter padding, smaller portraits/countdown, reduced font sizes
- Table scroll wrappers on standings tables
- Bug report button shrinks on mobile, save buttons go full-width
- Touch-friendly: `:active` states, `-webkit-overflow-scrolling`
- Desktop version completely unaffected — all changes inside `@media` queries

### Blue Colour Theme
- Season League pages use complementary blue (#4a9eff) accent instead of orange
- Applied via `.season-theme` body class — overrides accent, borders, glows, badges

### No Budget in Season League
- No salary cap, no price tags, no budget tracking
- Turbo driver has no salary cap restriction
- Purely about picking the best team

### Technical Changes
- 4 new DB tables: `season_teams`, `season_scores`, `season_pick_scores`, `season_pick_constructor_scores`
- New routes: `/season` (dashboard), `/season/team` (one-time picker), POST `/season` (turbo change)
- `score_season_league()` called automatically at end of `score_race()`
- Removed scoring rules from admin panel

## Test plan
- [ ] Pick a season team and verify it locks in permanently
- [ ] Verify turbo can be changed between races but not during lock
- [ ] Score a race and verify both leagues score correctly
- [ ] Check season leaderboard updates independently from main league
- [ ] Test hamburger menu on mobile — nav links toggle on tap
- [ ] Verify desktop layout is unchanged
- [ ] Test on small phone (375px) — cards stack, tables scroll, buttons are tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)